### PR TITLE
Add script to train neural network with KITTI dataset

### DIFF
--- a/src/train_kitti.py
+++ b/src/train_kitti.py
@@ -1,0 +1,35 @@
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from tensorflow import keras
+import cv2
+
+# Load the KITTI dataset
+dataset, info = tfds.load('kitti', split='train', with_info=True)
+
+# Define a neural network model for 2D object detection
+model = keras.Sequential([
+    keras.layers.Conv2D(32, (3, 3), activation='relu', input_shape=(None, None, 3)),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Conv2D(64, (3, 3), activation='relu'),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Conv2D(128, (3, 3), activation='relu'),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Flatten(),
+    keras.layers.Dense(128, activation='relu'),
+    keras.layers.Dense(4)  # Output layer for bounding box coordinates
+])
+
+# Preprocess the dataset for training
+def preprocess(data):
+    image = data['image']
+    bbox = data['objects']['bbox']
+    image = tf.image.resize(image, (128, 128))
+    return image, bbox
+
+train_dataset = dataset.map(preprocess).batch(32)
+
+# Compile the model
+model.compile(optimizer='adam', loss='mean_squared_error')
+
+# Train the neural network model using the preprocessed dataset
+model.fit(train_dataset, epochs=10)


### PR DESCRIPTION
Add a new Python script `src/train_kitti.py` to train a neural network with 2D object detection using the KITTI dataset from tensorflow-datasets.

* **Import necessary libraries**: Import `tensorflow`, `tensorflow_datasets`, `keras`, and `opencv-python`.
* **Load KITTI dataset**: Use `tensorflow_datasets.load` to load the KITTI dataset.
* **Define neural network model**: Create a neural network model for 2D object detection using Keras.
* **Preprocess dataset**: Define a preprocessing function to resize images and extract bounding boxes.
* **Compile and train model**: Compile the model with the Adam optimizer and mean squared error loss, and train it using the preprocessed dataset.

