### PR TITLE
Add script to train neural network with KITTI dataset (#1)

### DIFF
--- a/src/models/fred_model.py
+++ b/src/models/fred_model.py
@@ -1,0 +1,54 @@
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from tensorflow import keras
+from src.utils import handle_shape_mismatch, normalize_bboxes, convert_bboxes_to_fixed_size_tensor
+
+# Load the KITTI dataset
+dataset, info = tfds.load('kitti', split='train', with_info=True)
+
+# Define a neural network model for 2D object detection
+model = keras.Sequential([
+    keras.layers.Input(shape=(128, 128, 3)),
+    keras.layers.Conv2D(32, (3, 3), activation='relu'),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Conv2D(64, (3, 3), activation='relu'),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Conv2D(128, (3, 3), activation='relu'),
+    keras.layers.MaxPooling2D((2, 2)),
+    keras.layers.Flatten(),
+    keras.layers.Dense(128, activation='relu'),
+    keras.layers.Dense(40)  # Output layer for bounding box coordinates (10 bounding boxes * 4 coordinates each)
+])
+
+# Preprocess the dataset for training
+def preprocess(data):
+    image = data['image']
+    bbox = data['objects']['bbox']
+    image = tf.image.resize(image, (128, 128))
+    bbox = tf.reshape(bbox, [-1, 4])  # Ensure bbox shape is consistent
+    bbox = handle_shape_mismatch(bbox)  # Handle variable number of bounding boxes
+    bbox = normalize_bboxes(bbox, image.shape)  # Normalize bounding box coordinates
+    bbox = convert_bboxes_to_fixed_size_tensor(bbox)  # Convert to fixed size tensor
+    bbox = tf.reshape(bbox, [-1])  # Flatten the bounding boxes to match the model output shape
+    print(f"Image shape: {image.shape}, BBox shape: {bbox.shape}")  # Debugging statement
+    return image, bbox
+
+# Split the dataset into training, validation, and test sets
+train_dataset = dataset.take(int(0.8 * len(dataset)))
+val_dataset = dataset.skip(int(0.8 * len(dataset))).take(int(0.1 * len(dataset)))
+test_dataset = dataset.skip(int(0.9 * len(dataset)))
+
+# Preprocess the validation and test datasets
+train_dataset = train_dataset.map(preprocess).batch(32)
+val_dataset = val_dataset.map(preprocess).batch(32)
+test_dataset = test_dataset.map(preprocess).batch(32)
+
+# Compile the model
+model.compile(optimizer='adam', loss='mean_squared_error')
+
+# Train the neural network model using the preprocessed dataset
+model.fit(train_dataset, epochs=10, validation_data=val_dataset)
+
+# Evaluate the model's performance on the test dataset
+test_loss = model.evaluate(test_dataset)
+print(f"Test Loss: {test_loss}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,31 @@
+import tensorflow as tf
+
+def handle_shape_mismatch(bboxes, max_bboxes=10):
+    """
+    Handle variable numbers of bounding boxes by padding or truncating to a fixed size.
+    """
+    bboxes = bboxes[:max_bboxes]  # Truncate to max_bboxes
+    padding = [[0, max_bboxes - tf.shape(bboxes)[0]], [0, 0]]  # Padding for bboxes
+    bboxes = tf.pad(bboxes, padding)
+    return bboxes
+
+def normalize_bboxes(bboxes, image_shape):
+    """
+    Normalize bounding box coordinates to be between 0 and 1.
+    """
+    height, width = image_shape[0], image_shape[1]
+    bboxes = tf.cast(bboxes, tf.float32)
+    bboxes = tf.stack([
+        bboxes[:, 0] / height,
+        bboxes[:, 1] / width,
+        bboxes[:, 2] / height,
+        bboxes[:, 3] / width
+    ], axis=-1)
+    return bboxes
+
+def convert_bboxes_to_fixed_size_tensor(bboxes, max_bboxes=10):
+    """
+    Convert bounding boxes to a fixed size tensor.
+    """
+    bboxes = handle_shape_mismatch(bboxes, max_bboxes)
+    return bboxes


### PR DESCRIPTION
* Add script to train neural network with KITTI dataset

Add a new Python script `src/train_kitti.py` to train a neural network with 2D object detection using the KITTI dataset from tensorflow-datasets.

* **Import necessary libraries**: Import `tensorflow`, `tensorflow_datasets`, `keras`, and `opencv-python`.
* **Load KITTI dataset**: Use `tensorflow_datasets.load` to load the KITTI dataset.
* **Define neural network model**: Create a neural network model for 2D object detection using Keras.
* **Preprocess dataset**: Define a preprocessing function to resize images and extract bounding boxes.
* **Compile and train model**: Compile the model with the Adam optimizer and mean squared error loss, and train it using the preprocessed dataset.

* Add initial implementation of `train_kitti.py` for training a neural network on the KITTI dataset

* Import necessary libraries: `tensorflow`, `tensorflow_datasets`, and `keras`
* Load the KITTI dataset using `tensorflow_datasets.load`
* Define a neural network model for 2D object detection using `keras`
* Use `Input(shape)` object as the first layer in the model instead of passing `input_shape`/`input_dim` argument to a layer

* Reshape bounding box tensor to ensure consistent shape

* Add `tf.reshape` to bounding box tensor in `preprocess` function

* Add shape mismatch handling and KITTI dataset loading

* **src/train_kitti.py**
  - Import `handle_shape_mismatch` function from `src.utils`
  - Add try-except block to handle shape mismatch errors during model training
  - Load the KITTI dataset using `tensorflow_datasets.load`

* **src/utils.py**
  - Define `handle_shape_mismatch` function to reshape tensors to match the required shape
  - Import necessary libraries: `tensorflow`

* Add debugging statement to check shapes of images and bounding boxes in `preprocess` function

* Print image and bounding box shapes in `preprocess` function for debugging purposes

* Add functions to handle bounding box preprocessing and normalization

* **train_kitti.py**
  - Import `normalize_bboxes` and `convert_bboxes_to_fixed_size_tensor` from `src.utils`
  - Preprocess bounding boxes by handling shape mismatch, normalizing coordinates, and converting to fixed size tensor
  - Remove exception handling for shape mismatch during model training

* **utils.py**
  - Define `handle_shape_mismatch` to pad or truncate bounding boxes to a fixed size
  - Add `normalize_bboxes` to normalize bounding box coordinates
  - Add `convert_bboxes_to_fixed_size_tensor` to convert bounding boxes to a fixed size tensor

* Update model output layer and preprocess function to handle 10 bounding boxes

* **Model Output Layer**
  - Change output layer to `keras.layers.Dense(40)` to accommodate 10 bounding boxes with 4 coordinates each

* **Preprocess Function**
  - Add `tf.reshape(bbox, [-1])` to flatten bounding boxes to match model output shape
  - Add debugging statement to print image and bounding box shapes

* Update model output layer and preprocess function to handle 10 bounding boxes

* Split the dataset into training, validation, and test sets

* Preprocess the validation and test datasets
* Add validation data to model training
* Evaluate the model's performance on the test dataset